### PR TITLE
Upgrade version of cacheman-redis to match version of cacheman.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "cacheman": "^2.0.5",
-    "cacheman-redis": "^0.2.0",
+    "cacheman-redis": "^1.0.1",
     "jsosort": "0.0.0",
     "sha1": "^1.1.0"
   },


### PR DESCRIPTION
Dependency on `cacheman` is currently on version [2.0.5](https://github.com/cayasso/cacheman/releases/tag/2.0.5), dated Nov 1st, 2015.
This change bumps `cacheman-redis` to “matching” version [1.0.1](https://github.com/cayasso/cacheman-redis/releases/tag/1.0.1), also dated Nov 1st, 2015.

A practical benefit is the ability to bulk delete objects passing wildcards to `clearCache`.

`npm test` shows all 17 tests passing.