### PR TITLE
Cache empty option

### DIFF
--- a/lib-src/extend-aggregate.js
+++ b/lib-src/extend-aggregate.js
@@ -2,7 +2,7 @@ let generateKey     = require('./generate-key')
   , hasBeenExtended = false
   ;
 
-module.exports = function(mongoose, cache, debug) {
+module.exports = function(cacheOptions, mongoose, cache, debug) {
   let aggregate = mongoose.Model.aggregate;
 
   mongoose.Model.aggregate = function() {
@@ -38,6 +38,12 @@ module.exports = function(mongoose, cache, debug) {
           exec
             .call(this)
             .then(results => {
+                // Optionally ignore empty results
+                if (!cacheOptions.cacheEmpty && !results || (Array.isArray(results) && results.length === 0)) {
+                    callback(null, results);
+                    return resolve(results);
+                }
+
               cache.set(key, results, ttl, () => {
                 callback(null, results);
                 resolve(results);

--- a/lib-src/extend-query.js
+++ b/lib-src/extend-query.js
@@ -1,6 +1,6 @@
 let generateKey = require('./generate-key');
 
-module.exports = function(mongoose, cache, debug) {
+module.exports = function(cacheOptions, mongoose, cache, debug) {
   let exec = mongoose.Query.prototype.exec;
 
   mongoose.Query.prototype.exec = function(op, callback = function() { }) {
@@ -38,6 +38,12 @@ module.exports = function(mongoose, cache, debug) {
         exec
           .call(this)
           .then(results => {
+            // Optionally ignore empty results
+            if (!cacheOptions.cacheEmpty && (!results || (Array.isArray(results) && results.length === 0))) {
+                callback(null, results);
+                return resolve(results);
+            }
+
             cache.set(key, results, ttl, () => {
               callback(null, results);
               return resolve(results);

--- a/lib-src/index.js
+++ b/lib-src/index.js
@@ -9,8 +9,14 @@ module.exports = function init(mongoose, cacheOptions, debug) {
 
   init._cache = cache = require('./cache')(cacheOptions);
 
-  require('./extend-query')(mongoose, cache, debug);
-  require('./extend-aggregate')(mongoose, cache, debug);
+  // Ensure we're playing around with an object
+  var opts = typeof cacheOptions === 'object' ? cacheOptions : { url: cacheOptions };
+
+  // Default to caching empty things
+  opts.cacheEmpty = 'cacheEmpty' in opts ? !!opts.cacheEmpty : true;
+
+  require('./extend-query')(opts, mongoose, cache, debug);
+  require('./extend-aggregate')(opts, mongoose, cache, debug);
 };
 
 module.exports.clearCache = function(customKey, cb = function() { }) {

--- a/test/index.js
+++ b/test/index.js
@@ -37,6 +37,10 @@ describe('cachegoose', function() {
     Record = mongoose.model('Record', RecordSchema);
   });
 
+  after(function (done) {
+      mongoose.disconnect(done);
+  });
+
   beforeEach(function(done) {
     generate(10, done);
   });


### PR DESCRIPTION
Added an option for *not* caching empty responses.

We keep track of the clients to our API; generally they're in mongo (>99%; we want to cache this!), but every now and then, a new client shows up, which we then create once we've verified the data they've sent us. Caching the negative result creates a lot of headaches for us, so we'd love to skip it :)

(I've also considered using named keys and explicitly deleting them, but that looks to be a sizeable change to our applications. In particular, we'll be 100% sure to purge the cache quite a few places; not putting it there in the first place looks to be a simpler change...)