### PR TITLE
Add support for Mongoose@5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "should": "^13.2.1"
   },
   "scripts": {
-    "test": "npm run build && mocha",
+    "test": "npm run build && mocha --exit",
     "lint": "eslint .",
     "build": "babel src --out-dir out",
     "prepublish": "npm run lint && npm run build"

--- a/package.json
+++ b/package.json
@@ -7,21 +7,21 @@
     "test": "test"
   },
   "dependencies": {
-    "cacheman": "^2.0.5",
-    "cacheman-redis": "^1.0.1",
+    "cacheman": "^2.2.1",
+    "cacheman-redis": "^1.1.2",
     "jsosort": "0.0.0",
-    "sha1": "^1.1.0"
+    "sha1": "^1.1.1"
   },
   "peerDependencies": {
-    "mongoose": "^4.5.7"
+    "mongoose": "^5.0.1"
   },
   "devDependencies": {
-    "babel": "^5.0.12",
-    "eslint": "^4.10.0",
+    "babel-cli": "^6.26.0",
+    "eslint": "^4.16.0",
     "eslint-plugin-mocha": "^4.11.0",
-    "mocha": "~1.21.5",
-    "mongoose": "^4.5.7",
-    "should": "~4.0.4"
+    "mocha": "^5.0.0",
+    "mongoose": "^5.0.1",
+    "should": "^13.2.1"
   },
   "scripts": {
     "test": "npm run build && mocha",

--- a/src/extend-aggregate.js
+++ b/src/extend-aggregate.js
@@ -25,10 +25,8 @@ module.exports = function(mongoose, cache) {
 
       const key = this._key || this.getCacheKey();
       const ttl = this._ttl;
-      const Promise = mongoose.Promise;
-      ;
 
-      return new Promise.ES6((resolve, reject) => {
+      return new Promise((resolve, reject) => {
         cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
           if (cachedResults) {
             callback(null, cachedResults);

--- a/src/extend-query.js
+++ b/src/extend-query.js
@@ -20,9 +20,8 @@ module.exports = function(mongoose, cache) {
     const isCount = this.op === 'count';
     const isLean = this._mongooseOptions.lean;
     const model = this.model.modelName;
-    const Promise = mongoose.Promise;
 
-    return new Promise.ES6((resolve, reject) => {
+    return new Promise((resolve, reject) => {
       cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
         if (cachedResults) {
           if (isCount) {


### PR DESCRIPTION
Mongoose v5 was released last week and they dropped support for their custom Promise implementation (ie, `mongoose.Promise.ES6` is undefined, we need to use native promises instead).
Updated other deps to latest releases too.
It should certainly be tagged as a new breaking change major version as it won't work anymore with older Node.js version (