### PR TITLE
Support cache of zero result

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "eslint-plugin-mocha": "^4.11.0",
     "mocha": "^5.0.0",
     "mongoose": "^5.0.1",
-    "should": "^13.2.1"
+    "should": "^13.2.1",
+    "sinon": "^4.5.0"
   },
   "scripts": {
     "test": "npm run build && mocha --exit",

--- a/src/extend-query.js
+++ b/src/extend-query.js
@@ -23,7 +23,7 @@ module.exports = function(mongoose, cache) {
 
     return new Promise((resolve, reject) => {
       cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
-        if (cachedResults) {
+        if (cachedResults !== undefined && cachedResults !== null) {
           if (isCount) {
             callback(null, cachedResults);
             return resolve(cachedResults);

--- a/test/index.js
+++ b/test/index.js
@@ -3,6 +3,7 @@
 require('should');
 
 const mongoose = require('mongoose');
+const sinon = require('sinon');
 const cachegoose = require('../out');
 const Schema = mongoose.Schema;
 
@@ -277,6 +278,15 @@ describe('cachegoose', () => {
 
     const cached = await count(60);
     cached.should.equal(10);
+  });
+
+  it('should cache a count query with zero result', async () => {
+    const spy = sinon.spy(cache, 'set');
+    await Record.remove();
+    const res = await count(60);
+    res.should.equal(0);
+    await count(60);
+    sinon.assert.calledOnce(spy);
   });
 
   it('should correctly cache a query with a sort order', async () => {


### PR DESCRIPTION
In result of query can be negative result: `0` or `false` for example.