### PR TITLE
Added Model helper to clearCache

### DIFF
--- a/src/extend-aggregate.js
+++ b/src/extend-aggregate.js
@@ -17,6 +17,15 @@ module.exports = function(mongoose, cache) {
     return res;
   };
 
+  // add helper function refs to model
+  mongoose.Model.clearCache = function (customKey, cb = () => {}) {
+    if (!customKey) {
+      cache._cache.clear(cb);
+      return;
+    }
+    cache._cache.del(customKey, cb);
+  };
+
   function extend(Aggregate) {
     const exec = Aggregate.prototype.exec;
 

--- a/src/extend-aggregate.js
+++ b/src/extend-aggregate.js
@@ -18,7 +18,7 @@ module.exports = function(mongoose, cache) {
   };
 
   // add helper function refs to model
-  mongoose.Model.clearCache = function (customKey, cb = () => {}) {
+  mongoose.Model.clearCache = function(customKey, cb = () => {}) {
     if (!customKey) {
       cache._cache.clear(cb);
       return;


### PR DESCRIPTION
Added to make it a bit easier to clear the cache when saving a model.

``` js
Children
  .find({ parentId: userId })
  .cache(0, userId + '-children') /* Will create a redis entry          */
  .exec(function(err, records) {  /* with the key '1234567890-children' */
    ...
  });

ChildrenSchema.post('save', function(child) {
  // Clear the parent's cache, since a new child has been added.
  ChildrenSchema.clearCache(child.parentId + '-children');
});
```
In some ways, this is slightly confusing, as the user may assume that by *not* passing a key, all caches corresponding to the Children will be cleared, although though this is not the case - it is global. This could be resolved by modifying the cacheKey so that it is prefixed by the Schema name, although I'm unsure of how to pull back all keys from cacheman?
