### PR TITLE
Bugfix: Return _id as ObjectId from cache

### DIFF
--- a/src/extend-aggregate.js
+++ b/src/extend-aggregate.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const generateKey = require('./generate-key');
+const recoverObjectId = require('./recover-objectid');
 let hasBeenExtended = false;
 
 module.exports = function(mongoose, cache) {
@@ -28,7 +29,9 @@ module.exports = function(mongoose, cache) {
 
       return new Promise((resolve, reject) => {
         cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
-          if (cachedResults) {
+          if (cachedResults != null) {
+            cachedResults = recoverObjectId(mongoose, cachedResults);
+
             callback(null, cachedResults);
             return resolve(cachedResults);
           }

--- a/src/extend-query.js
+++ b/src/extend-query.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const generateKey = require('./generate-key');
+const recoverObjectId = require('./recover-objectid');
 
 module.exports = function(mongoose, cache) {
   const exec = mongoose.Query.prototype.exec;
@@ -35,9 +36,7 @@ module.exports = function(mongoose, cache) {
               cachedResults.map(hydrateModel(constructor)) :
               hydrateModel(constructor)(cachedResults);
           } else {
-            Array.isArray(cachedResults) ?
-              cachedResults.forEach(recoverObjectId(mongoose)) :
-              recoverObjectId(mongoose)(cachedResults);
+            cachedResults = recoverObjectId(mongoose, cachedResults);
           }
 
           callback(null, cachedResults);
@@ -93,14 +92,4 @@ function hydrateModel(constructor) {
   return (data) => {
     return constructor.hydrate(data);
   };
-}
-
-function recoverObjectId(mongoose) {
-  return data => {
-    if (!data._id) {
-      return data;
-    }
-
-    data._id = mongoose.Types.ObjectId(data._id);
-  }
 }

--- a/src/extend-query.js
+++ b/src/extend-query.js
@@ -34,6 +34,10 @@ module.exports = function(mongoose, cache) {
             cachedResults = Array.isArray(cachedResults) ?
               cachedResults.map(hydrateModel(constructor)) :
               hydrateModel(constructor)(cachedResults);
+          } else {
+            Array.isArray(cachedResults) ?
+              cachedResults.forEach(recoverObjectId(mongoose)) :
+              recoverObjectId(mongoose)(cachedResults);
           }
 
           callback(null, cachedResults);
@@ -89,4 +93,14 @@ function hydrateModel(constructor) {
   return (data) => {
     return constructor.hydrate(data);
   };
+}
+
+function recoverObjectId(mongoose) {
+  return data => {
+    if (!data._id) {
+      return data;
+    }
+
+    data._id = mongoose.Types.ObjectId(data._id);
+  }
 }

--- a/src/recover-objectid.js
+++ b/src/recover-objectid.js
@@ -1,0 +1,18 @@
+'use strict';
+
+module.exports = function(mongoose, cachedResults) {
+  return Array.isArray(cachedResults) ?
+    cachedResults.map(recoverObjectId(mongoose)) :
+    recoverObjectId(mongoose)(cachedResults);
+};
+
+function recoverObjectId(mongoose) {
+  return data => {
+    if (!data._id) {
+      return data;
+    }
+
+    data._id = mongoose.Types.ObjectId(data._id);
+    return data;
+  }
+}

--- a/test/index.js
+++ b/test/index.js
@@ -367,6 +367,14 @@ describe('cachegoose', () => {
     const cachedConstructor = cachedRes._id.constructor.name.should;
     originalConstructor.should.deepEqual(cachedConstructor);
   });
+
+  it('should return similar _id in cached array result for aggregate', async () => {
+    const originalRes = await aggregateAll(60);
+    const cachedRes = await aggregateAll(60);
+    const originalConstructor = originalRes[0]._id.constructor.name.should;
+    const cachedConstructor = cachedRes[0]._id.constructor.name.should;
+    originalConstructor.should.deepEqual(cachedConstructor);
+  });
 });
 
 function getAll(ttl, cb) {
@@ -448,6 +456,14 @@ function estimatedDocumentCount(ttl, cb) {
 function aggregate(ttl, cb) {
   return Record.aggregate()
     .group({ _id: null, total: { $sum: '$num' } })
+    .cache(ttl)
+    .exec(cb);
+}
+
+function aggregateAll(ttl, cb) {
+  return Record.aggregate([
+    { $match: {}},
+  ])
     .cache(ttl)
     .exec(cb);
 }

--- a/test/index.js
+++ b/test/index.js
@@ -351,6 +351,22 @@ describe('cachegoose', () => {
     const diffSort = await getAllSorted({ num: -1 });
     diffSort.length.should.equal(20);
   });
+
+  it('should return similar _id in cached array result for lean', async () => {
+    const originalRes = await getAllLean(60);
+    const cachedRes = await getAllLean(60);
+    const originalConstructor = originalRes[0]._id.constructor.name.should;
+    const cachedConstructor = cachedRes[0]._id.constructor.name.should;
+    originalConstructor.should.deepEqual(cachedConstructor);
+  });
+
+  it('should return similar _id in one cached result for lean', async () => {
+    const originalRes = await getOneLean(60);
+    const cachedRes = await getOneLean(60);
+    const originalConstructor = originalRes._id.constructor.name.should;
+    const cachedConstructor = cachedRes._id.constructor.name.should;
+    originalConstructor.should.deepEqual(cachedConstructor);
+  });
 });
 
 function getAll(ttl, cb) {
@@ -371,6 +387,10 @@ function getAllLean(ttl, cb) {
 
 function getOne(ttl, cb) {
   return Record.findOne({ num: { $gt: 2 } }).cache(ttl).exec(cb);
+}
+
+function getOneLean(ttl, cb) {
+  return Record.findOne({ num: { $gt: 2 } }).lean().cache(ttl).exec(cb);
 }
 
 function getWithSkip(skip, ttl, cb) {


### PR DESCRIPTION
Despite the use of `lean()` mongoose returns `_id` field as instance of ObjectId. But in cached result this field returned as a string.