### PR TITLE
Improve: Support null ttl to disable caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,13 @@ Record
   .exec(function(err, aggResults) {
     ...
   });
+
+Record
+  .find({})
+  .cache(null) // Explicitly passing in null will not cache the results.
+  .exec(function(err, records) {
+    ...
+  });
 ```
 
 You can also pass a custom key into the `.cache()` method, which you can then use later to clear the cached content.

--- a/src/cache.js
+++ b/src/cache.js
@@ -12,6 +12,7 @@ Cache.prototype.get = function(key, cb = noop) {
 };
 
 Cache.prototype.set = function(key, value, ttl, cb = noop) {
+  if (ttl === null) return cb();
   if (ttl === 0) ttl = -1;
   return this._cache.set(key, value, ttl, cb);
 };

--- a/src/extend-aggregate.js
+++ b/src/extend-aggregate.js
@@ -28,7 +28,7 @@ module.exports = function(mongoose, cache) {
 
       return new Promise((resolve, reject) => {
         cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
-          if (cachedResults) {
+          if (cachedResults != null && ttl !== null) {
             callback(null, cachedResults);
             return resolve(cachedResults);
           }

--- a/src/extend-query.js
+++ b/src/extend-query.js
@@ -23,7 +23,7 @@ module.exports = function(mongoose, cache) {
 
     return new Promise((resolve, reject) => {
       cache.get(key, (err, cachedResults) => { //eslint-disable-line handle-callback-err
-        if (cachedResults != null) {
+        if (cachedResults != null && ttl !== null) {
           if (isCount) {
             callback(null, cachedResults);
             return resolve(cachedResults);

--- a/test/index.js
+++ b/test/index.js
@@ -80,7 +80,7 @@ describe('cachegoose', () => {
     cachedRes.length.should.equal(10);
   });
 
-  it('should not cache the same query w/out a ttl defined', async () => {
+  it('should not cache the same query w/out a cachegoose invoking', async () => {
     const res = await getAll(60);
     res.length.should.equal(10);
 
@@ -88,6 +88,24 @@ describe('cachegoose', () => {
 
     const nonCachedResponse = await getAllNoCache();
     nonCachedResponse.length.should.equal(20);
+  });
+
+  it('should not cache query w/out a ttl defined', async () => {
+    const res = await getAll(null);
+    res.length.should.equal(10);
+
+    await generate(10);
+    const cachedRes = await getAll(null);
+    cachedRes.length.should.equal(20);
+  });
+
+  it('should clear cache w/out a ttl defined', async () => {
+    const res = await getAll(60);
+    res.length.should.equal(10);
+
+    await generate(10);
+    const cachedRes = await getAll(null);
+    cachedRes.length.should.equal(20);
   });
 
   it('should return a Mongoose model from cached and non-cached results', (done) => {


### PR DESCRIPTION
In case when we have predefined queries with cache invoking and when we need possibility to disable caching it more convenient to change TTL than calling cache method by condition.

For example:

```js
class DB {
    constructor(cacheTTL) {
        this.cacheTTL = cacheTTL;
    }

    findAll() {
        return Record
          .find({})
          .cache(this.cacheTTL)
          .exec(function(err, records) {
            ...
          });
    }
}

new DB(0).findAll(); // Set and get results with cache.
new DB(null).findAll(); // Don't use cache.
```

### Another approach

In general, I would do the following cache TTL value principle:
- `Infinity` — Indefinitely caching results
- `60` — Caching for specified time
- `0` — Disable caching (cache for 0 seconds)

But that will entail major changes and for this reason I suggest to use `null` for disable caching.